### PR TITLE
Fix memcpy overlap in AAC encoder

### DIFF
--- a/libavcodec/aacenc.c
+++ b/libavcodec/aacenc.c
@@ -485,7 +485,7 @@ static void apply_window_and_mdct(AACEncContext *s, SingleChannelElement *sce,
     else
         for (i = 0; i < 1024; i += 128)
             s->mdct128_fn(s->mdct128, &sce->coeffs[i], output + i*2, sizeof(float));
-    memcpy(audio, audio + 1024, sizeof(audio[0]) * 1024);
+    memmove(audio, audio + 1024, sizeof(audio[0]) * 1024);
     memcpy(sce->pcoeffs, sce->coeffs, sizeof(sce->pcoeffs));
 }
 
@@ -808,7 +808,7 @@ static void copy_input_samples(AACEncContext *s, const AVFrame *frame)
     /* copy and remap input samples */
     for (ch = 0; ch < s->channels; ch++) {
         /* copy last 1024 samples of previous frame to the start of the current frame */
-        memcpy(&s->planar_samples[ch][1024], &s->planar_samples[ch][2048], 1024 * sizeof(s->planar_samples[0][0]));
+        memmove(&s->planar_samples[ch][1024], &s->planar_samples[ch][2048], 1024 * sizeof(s->planar_samples[0][0]));
 
         /* copy new samples and zero any remaining samples */
         if (frame) {

--- a/libavcodec/aacpsy.c
+++ b/libavcodec/aacpsy.c
@@ -230,8 +230,8 @@ static float lame_calc_attack_threshold(int bitrate)
 {
     /* Assume max bitrate to start with */
     int lower_range = 12, upper_range = 12;
-    int lower_range_kbps = psy_abr_map[12].quality;
-    int upper_range_kbps = psy_abr_map[12].quality;
+    int lower_range_kbps = psy_abr_map[lower_range].quality;
+    int upper_range_kbps = psy_abr_map[upper_range].quality;
     int i;
 
     /* Determine which bitrates the value specified falls between.


### PR DESCRIPTION
## Summary
- use `memmove` for overlapping AAC audio buffer copies
- refer to variables in ABR range initializations to remove duplicate assignment

## Testing
- `cppcheck --enable=warning --error-exitcode=1 libavcodec/aacenc.c libavcodec/aacpsy.c`

------
https://chatgpt.com/codex/tasks/task_e_68410b00b1f48322ace1446b33b1ac04